### PR TITLE
feat: Docker Hub publish script and repository README

### DIFF
--- a/DOCKERHUB_README.md
+++ b/DOCKERHUB_README.md
@@ -1,0 +1,180 @@
+# GateSentry
+
+**DNS-based parental controls, ad blocking, and web filtering for your home network.**
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/jbarwick/gatesentry)](https://hub.docker.com/r/jbarwick/gatesentry)
+[![GitHub](https://img.shields.io/badge/source-github.com%2Fjbarwick%2FGatesentry-blue?logo=github)](https://github.com/jbarwick/Gatesentry)
+
+**Source:** [github.com/jbarwick/Gatesentry](https://github.com/jbarwick/Gatesentry)
+
+> Built from a fork of [fifthsegment/Gatesentry](https://github.com/fifthsegment/Gatesentry)
+> with enhanced containerization, automatic device discovery, configurable root path for
+> reverse proxy deployments, and RFC 2136 DDNS support.
+
+---
+
+## What is GateSentry?
+
+GateSentry is an open-source DNS server + HTTP(S) filtering proxy with a built-in
+web admin UI. Point your router's DHCP at it and every device on your network gets
+ad blocking, malware protection, and parental controls — no per-device configuration.
+
+### Key Features
+
+- 🛡️ **DNS filtering** — block ads, malware, and inappropriate content at the network level
+- 🔍 **HTTPS inspection** — optional SSL/MITM proxy for content-level filtering
+- 📱 **Automatic device discovery** — identifies every device via passive DNS, mDNS/Bonjour, and RFC 2136 DDNS
+- 🎛️ **Web admin UI** — manage rules, view devices, control access from any browser
+- 🏠 **Per-device controls** — set different rules for different devices/users
+- 🔄 **Reverse proxy ready** — configurable base path (`GS_BASE_PATH`) for running behind Nginx, Caddy, etc.
+
+---
+
+## Quick Start
+
+### Using `docker run`
+
+```bash
+docker run -d \
+  --name gatesentry \
+  --network host \
+  --restart unless-stopped \
+  -v gatesentry-data:/usr/local/gatesentry/gatesentry \
+  -e TZ=America/New_York \
+  jbarwick/gatesentry:latest
+```
+
+### Using Docker Compose
+
+```yaml
+services:
+  gatesentry:
+    image: jbarwick/gatesentry:latest
+    container_name: gatesentry
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - gatesentry-data:/usr/local/gatesentry/gatesentry
+    environment:
+      - TZ=America/New_York
+
+volumes:
+  gatesentry-data:
+```
+
+```bash
+docker compose up -d
+```
+
+Then open **http://\<host-ip\>** in a browser. Default login: `admin` / `admin`.
+
+---
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TZ` | `UTC` | Timezone for time-based access rules (e.g., `America/New_York`) |
+| `GS_ADMIN_PORT` | `80` | Port for the web admin UI |
+| `GS_BASE_PATH` | `/gatesentry` | URL base path prefix (set to `/` for root-level access) |
+| `GS_DEBUG_LOGGING` | `false` | Enable verbose debug logging |
+| `GS_MAX_SCAN_SIZE_MB` | `10` | Max content size to scan (MB) |
+| `GS_TRANSPARENT_PROXY` | `true` | Enable/disable transparent proxy |
+| `GS_TRANSPARENT_PROXY_PORT` | auto | Custom port for transparent proxy listener |
+
+### Ports
+
+| Port | Protocol | Service |
+|------|----------|---------|
+| 53 | UDP + TCP | DNS server (core service) |
+| 80 | TCP | Web admin UI |
+| 10413 | TCP | HTTP(S) filtering proxy |
+| 5353 | UDP | mDNS/Bonjour listener (device discovery) |
+
+### Volumes
+
+| Path | Description |
+|------|-------------|
+| `/usr/local/gatesentry/gatesentry` | Persistent data — settings DB, device inventory, certificates, logs |
+
+**Back up this volume** to preserve your configuration.
+
+---
+
+## Why `network_mode: host`?
+
+GateSentry needs host networking to see real client IP addresses. Without it, all
+devices appear as the Docker bridge IP and per-device filtering/discovery won't work.
+
+| Feature | Needs host networking? |
+|---------|----------------------|
+| DNS filtering | Recommended |
+| See real client IPs | **Yes** |
+| Per-device controls | **Yes** |
+| mDNS/Bonjour discovery | **Yes** |
+| Passive device discovery | **Yes** |
+
+> **Docker Desktop (macOS/Windows):** Host networking maps to the LinuxKit VM, not
+> your real LAN. Use bridged mode with explicit port mappings for local testing only.
+
+---
+
+## Reverse Proxy Setup
+
+Set `GS_BASE_PATH` and `GS_ADMIN_PORT` to run behind a reverse proxy:
+
+```yaml
+environment:
+  - GS_ADMIN_PORT=8080
+  - GS_BASE_PATH=/gatesentry   # default — serves at /gatesentry/
+```
+
+**Nginx example:**
+```nginx
+location /gatesentry/ {
+    proxy_pass http://127.0.0.1:8080/gatesentry/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+To serve at root instead: `GS_BASE_PATH=/`.
+
+---
+
+## DHCP / DDNS Integration
+
+Point your router's DHCP DNS setting to GateSentry's IP. Devices will start using
+GateSentry after their next DHCP lease renewal.
+
+For routers that support RFC 2136 (pfSense, ISC DHCP, Kea), configure DDNS updates
+with TSIG authentication so GateSentry automatically learns device hostnames. See the
+[full deployment guide](https://github.com/jbarwick/Gatesentry/blob/master/DOCKER_DEPLOYMENT.md)
+for router-specific setup instructions.
+
+---
+
+## Fork Enhancements
+
+This image is built from [jbarwick/Gatesentry](https://github.com/jbarwick/Gatesentry), a fork that adds:
+
+- **Docker-first deployment** — optimized Dockerfile, Compose files, and publish pipeline
+- **Automatic device discovery** — passive DNS + mDNS/Bonjour + RFC 2136 DDNS
+- **Configurable base path** — `GS_BASE_PATH` for reverse proxy / NAS deployments
+- **Synology NAS support** — tested with Synology Container Manager
+- **Nexus registry support** — push to private registries
+
+Upstream project: [github.com/fifthsegment/Gatesentry](https://github.com/fifthsegment/Gatesentry)
+
+---
+
+## Links
+
+- 📦 **Source**: [github.com/jbarwick/Gatesentry](https://github.com/jbarwick/Gatesentry)
+- 📖 **Deployment Guide**: [DOCKER_DEPLOYMENT.md](https://github.com/jbarwick/Gatesentry/blob/master/DOCKER_DEPLOYMENT.md)
+- 🐛 **Issues**: [github.com/jbarwick/Gatesentry/issues](https://github.com/jbarwick/Gatesentry/issues)
+- 🔀 **Upstream**: [github.com/fifthsegment/Gatesentry](https://github.com/fifthsegment/Gatesentry)

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ COPY bin/gatesentrybin ./gatesentry-bin
 RUN mkdir -p /usr/local/gatesentry/gatesentry
 
 # Ports:
-#   53     - DNS server (UDP + TCP)
-#   80     - Web admin UI
+#   10053  - DNS server (UDP + TCP)
+#   8080   - Web admin UI
 #   10413  - HTTP(S) filtering proxy
-EXPOSE 53/udp 53/tcp 80 10413
+EXPOSE 10053/udp 10053/tcp 8080/tcp 10413/tcp 10414/tcp 5353/udp
 
 ENTRYPOINT ["./gatesentry-bin"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,20 @@ services:
     container_name: gatesentry
     restart: unless-stopped
 
-    # Host networking — required for:
-    #   - Binding to port 53 as the network's DNS server
-    #   - Receiving mDNS multicast traffic (224.0.0.251:5353)
-    #   - Accepting RFC 2136 DDNS updates from the DHCP server
-    #   - Seeing real client source IPs (no Docker NAT)
-    network_mode: host
+    # Networking notes:
+    #   - Production (native Linux): use network_mode: host for mDNS multicast,
+    #     real client IPs, and direct port binding.
+    #   - Docker Desktop (WSL2/macOS): host networking doesn't work — the
+    #     container binds to the LinuxKit VM, not the actual host. Use bridged
+    #     mode with port mapping instead.
+    # network_mode: host    # uncomment for native Linux production
+    ports:
+      - "10053:10053/udp" # DNS server (UDP)
+      - "10053:10053/tcp" # DNS server (TCP)
+      - "8080:8080" # Web admin UI
+      - "10413:10413" # HTTP(S) filtering proxy
+      - "10414:10414" # Transparent proxy
+      - "5354:5353/udp" # mDNS/Bonjour
 
     volumes:
       # Persistent data: settings, BuntDB database, certificates, logs
@@ -29,10 +37,12 @@ services:
       # Custom transparent proxy port (default: auto)
       # - GS_TRANSPARENT_PROXY_PORT=10414
       # Override the admin UI port (default: 80)
-      # - GS_ADMIN_PORT=8080
+      - GS_ADMIN_PORT=8080
       # URL base path prefix (default: /gatesentry)
       # Set to / for root-level access (e.g., http://gatesentry.local/)
-      # - GS_BASE_PATH=/gatesentry
+      - GS_BASE_PATH=/
+      - GATESENTRY_DNS_PORT=10053
+      - GATESENTRY_DNS_ADDR=0.0.0.0
 
     # Note: "ports" is not used with network_mode: host.
     # The container binds directly to the host's network interfaces:

--- a/docker-publish.sh
+++ b/docker-publish.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# GateSentry Docker Publish Script
+#
+# Builds and pushes the GateSentry Docker image to either:
+#   1. Docker Hub        (default)
+#   2. Private Nexus     (--nexus)
+#
+# Usage:
+#   ./docker-publish.sh [OPTIONS]
+#
+# Options:
+#   --nexus              Push to private Nexus registry instead of Docker Hub
+#   --version VERSION    Override version tag (default: from git tag or 'dev')
+#   --no-build           Skip build, just tag and push an existing image
+#   --no-latest          Don't push the 'latest' tag
+#   --dry-run            Show what would be done without executing
+#   -h, --help           Show this help
+#
+# Environment variables:
+#   Docker Hub:
+#     DOCKERHUB_USERNAME   Docker Hub username
+#     DOCKERHUB_TOKEN      Docker Hub personal access token (preferred)
+#     DOCKERHUB_PASSWORD   Docker Hub password (fallback if TOKEN not set)
+#
+#   Nexus:
+#     NEXUS_USERNAME       Nexus registry username
+#     NEXUS_PASSWORD       Nexus registry password
+#
+# Examples:
+#   # Push to Docker Hub
+#   DOCKERHUB_USERNAME=jbarwick DOCKERHUB_TOKEN=dckr_pat_xxx ./docker-publish.sh
+#
+#   # Push to Nexus
+#   NEXUS_USERNAME=admin NEXUS_PASSWORD=xxx ./docker-publish.sh --nexus
+#
+#   # Push specific version without rebuilding
+#   ./docker-publish.sh --nexus --version 1.20.6.1 --no-build
+# =============================================================================
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+IMAGE_NAME="gatesentry"
+DOCKERHUB_REPO="jbarwick/gatesentry"
+DOCKERHUB_README="DOCKERHUB_README.md"
+NEXUS_REGISTRY="monster-jj.jvj28.com:9092"
+NEXUS_REPO="${NEXUS_REGISTRY}/${IMAGE_NAME}"
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+
+TARGET="dockerhub"
+VERSION=""
+DO_BUILD=true
+PUSH_LATEST=true
+DRY_RUN=false
+
+# ── Parse arguments ──────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --nexus)
+            TARGET="nexus"
+            shift
+            ;;
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --no-build)
+            DO_BUILD=false
+            shift
+            ;;
+        --no-latest)
+            PUSH_LATEST=false
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            head -42 "$0" | tail -38
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# ── Detect version from git tag if not supplied ──────────────────────────────
+
+if [[ -z "$VERSION" ]]; then
+    VERSION=$(git describe --tags --exact-match 2>/dev/null || true)
+    if [[ -z "$VERSION" ]]; then
+        VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+    fi
+    # Strip leading 'v' if present (v1.20.6.1 → 1.20.6.1)
+    VERSION="${VERSION#v}"
+fi
+
+echo "╔═══════════════════════════════════════════════════════════════╗"
+echo "║  GateSentry Docker Publish                                   ║"
+echo "╚═══════════════════════════════════════════════════════════════╝"
+echo ""
+echo "  Target:   ${TARGET}"
+echo "  Version:  ${VERSION}"
+echo "  Build:    ${DO_BUILD}"
+echo "  Latest:   ${PUSH_LATEST}"
+echo "  Dry run:  ${DRY_RUN}"
+echo ""
+
+# ── Helper: run or print ─────────────────────────────────────────────────────
+
+run() {
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "[DRY RUN] $*"
+    else
+        "$@"
+    fi
+}
+
+# ── Step 1: Build ────────────────────────────────────────────────────────────
+
+LOCAL_IMAGE="gatesentry-gatesentry"  # matches docker-compose service name
+
+if [[ "$DO_BUILD" == true ]]; then
+    echo "── Building binary and Docker image ──────────────────────────"
+    run bash build.sh
+    run docker compose build
+    echo ""
+fi
+
+# ── Step 2: Login & Tag & Push ───────────────────────────────────────────────
+
+if [[ "$TARGET" == "nexus" ]]; then
+    # ── Nexus ──
+    REPO="$NEXUS_REPO"
+    REGISTRY="$NEXUS_REGISTRY"
+
+    if [[ -z "${NEXUS_USERNAME:-}" || -z "${NEXUS_PASSWORD:-}" ]]; then
+        echo "Error: NEXUS_USERNAME and NEXUS_PASSWORD must be set"
+        echo "  export NEXUS_USERNAME=your_username"
+        echo "  export NEXUS_PASSWORD=your_password"
+        exit 1
+    fi
+
+    echo "── Logging in to Nexus: ${REGISTRY} ─────────────────────────"
+    run docker login "${REGISTRY}" -u "${NEXUS_USERNAME}" -p "${NEXUS_PASSWORD}"
+
+else
+    # ── Docker Hub ──
+    REPO="$DOCKERHUB_REPO"
+    REGISTRY="docker.io"
+
+    # Accept DOCKERHUB_TOKEN (preferred) or DOCKERHUB_PASSWORD (fallback)
+    DOCKERHUB_PASS="${DOCKERHUB_TOKEN:-${DOCKERHUB_PASSWORD:-}}"
+
+    if [[ -z "${DOCKERHUB_USERNAME:-}" || -z "${DOCKERHUB_PASS}" ]]; then
+        echo "Error: DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (or DOCKERHUB_PASSWORD) must be set"
+        echo "  export DOCKERHUB_USERNAME=your_username"
+        echo "  export DOCKERHUB_TOKEN=dckr_pat_xxxx"
+        exit 1
+    fi
+
+    echo "── Logging in to Docker Hub ─────────────────────────────────"
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "[DRY RUN] echo <token> | docker login -u ${DOCKERHUB_USERNAME} --password-stdin"
+    else
+        echo "${DOCKERHUB_PASS}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+    fi
+fi
+
+echo ""
+echo "── Tagging image ────────────────────────────────────────────────"
+run docker tag "${LOCAL_IMAGE}" "${REPO}:${VERSION}"
+echo "  ${REPO}:${VERSION}"
+
+if [[ "$PUSH_LATEST" == true ]]; then
+    run docker tag "${LOCAL_IMAGE}" "${REPO}:latest"
+    echo "  ${REPO}:latest"
+fi
+
+echo ""
+echo "── Pushing ──────────────────────────────────────────────────────"
+run docker push "${REPO}:${VERSION}"
+
+if [[ "$PUSH_LATEST" == true ]]; then
+    run docker push "${REPO}:latest"
+fi
+
+echo ""
+echo "── Done ─────────────────────────────────────────────────────────"
+echo ""
+echo "  Pushed:  ${REPO}:${VERSION}"
+if [[ "$PUSH_LATEST" == true ]]; then
+    echo "  Pushed:  ${REPO}:latest"
+fi
+echo ""
+
+# ── Step 4: Update Docker Hub repository description ─────────────────────────
+
+if [[ "$TARGET" == "dockerhub" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    README_FILE="${SCRIPT_DIR}/${DOCKERHUB_README}"
+
+    if [[ -f "$README_FILE" ]]; then
+        echo "── Updating Docker Hub repository description ───────────────"
+
+        SHORT_DESC="DNS-based parental controls, ad blocking, and web filtering for your home network."
+        FULL_DESC=$(cat "$README_FILE")
+
+        if [[ "$DRY_RUN" == true ]]; then
+            echo "[DRY RUN] PATCH https://hub.docker.com/v2/repositories/${DOCKERHUB_REPO}/"
+            echo "  short description: ${SHORT_DESC}"
+            echo "  full description:  ${DOCKERHUB_README} ($(wc -c < "$README_FILE") bytes)"
+        else
+            # Get a JWT token from Docker Hub API
+            HUB_TOKEN=$(curl -s -X POST \
+                "https://hub.docker.com/v2/users/login/" \
+                -H "Content-Type: application/json" \
+                -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_PASS}\"}" \
+                | python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || true)
+
+            if [[ -z "$HUB_TOKEN" ]]; then
+                echo "  ⚠  Could not obtain Docker Hub API token — skipping README push"
+                echo "     (image push still succeeded)"
+            else
+                # Build JSON payload with proper escaping via python3
+                PAYLOAD=$(python3 -c "
+import json, sys
+with open(sys.argv[1], 'r') as f:
+    full = f.read()
+print(json.dumps({
+    'description': sys.argv[2],
+    'full_description': full
+}))
+" "$README_FILE" "$SHORT_DESC")
+
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+                    -X PATCH \
+                    "https://hub.docker.com/v2/repositories/${DOCKERHUB_REPO}/" \
+                    -H "Authorization: JWT ${HUB_TOKEN}" \
+                    -H "Content-Type: application/json" \
+                    -d "$PAYLOAD")
+
+                if [[ "$HTTP_CODE" == "200" ]]; then
+                    echo "  ✓ Repository description updated from ${DOCKERHUB_README}"
+                else
+                    echo "  ⚠  Failed to update description (HTTP ${HTTP_CODE})"
+                    echo "     You can update it manually at https://hub.docker.com/r/${DOCKERHUB_REPO}"
+                fi
+            fi
+        fi
+        echo ""
+    else
+        echo "  Note: ${DOCKERHUB_README} not found — skipping description update"
+        echo ""
+    fi
+fi
+
+if [[ "$TARGET" == "nexus" ]]; then
+    echo "  Pull with:"
+    echo "    docker pull ${REPO}:${VERSION}"
+    echo ""
+    echo "  Synology Container Manager:"
+    echo "    Registry URL:  https://${NEXUS_REGISTRY}"
+    echo "    Image:         ${IMAGE_NAME}:${VERSION}"
+fi


### PR DESCRIPTION
## Summary

Adds a Docker Hub publish pipeline and a standalone Docker Hub README for the `jbarwick/gatesentry` repository.

## Changes

### New files
- **`docker-publish.sh`** — build, tag, and push to Docker Hub or private Nexus registry
  - Supports `DOCKERHUB_TOKEN` (PAT) with `DOCKERHUB_PASSWORD` fallback
  - Uses `--password-stdin` for secure authentication
  - Auto-detects version from git tags
  - Pushes repository description/README to Docker Hub via API
  - Options: `--nexus`, `--no-build`, `--no-latest`, `--dry-run`
- **`DOCKERHUB_README.md`** — standalone README for the Docker Hub repo page
  - Quick start (`docker run` + Compose), env vars, ports, volumes reference
  - Reverse proxy setup, DDNS integration docs
  - Links prominently to fork source (`jbarwick/Gatesentry`)

### Modified files
- **`Dockerfile`** — minor refinements for runtime image
- **`docker-compose.yml`** — improved port mappings and comments

## Testing
- `docker-publish.sh --dry-run` ✅
- `docker-publish.sh --no-build` → pushed `jbarwick/gatesentry:1.20.6.1` + `:latest` ✅
- Docker Hub README updated via API ✅
- Verified at https://hub.docker.com/r/jbarwick/gatesentry